### PR TITLE
fix: Enable marketplace publishing with AZURE_TOKEN secret

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -133,8 +133,10 @@ jobs:
       - name: Check Azure token availability
         id: check_token
         if: steps.version_check.outputs.changed == 'true'
+        env:
+          AZURE_TOKEN: ${{ secrets.AZURE_TOKEN }}
         run: |
-          if [ -n "${{ secrets.AZURE_TOKEN }}" ]; then
+          if [ -n "$AZURE_TOKEN" ]; then
             echo "has_token=true" >> $GITHUB_OUTPUT
           else
             echo "has_token=false" >> $GITHUB_OUTPUT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the "Kafka Client" extension will be documented in this f
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.0.3](https://github.com/nipunap/vscode-kafka-client/compare/v0.0.2...v0.0.3) (2025-10-05)
+
+
+### 🐛 Bug Fixes
+
+* properly check AZURE_TOKEN secret availability ([7103d33](https://github.com/nipunap/vscode-kafka-client/commit/7103d336be8d827837360146bae44e8cd4ce927d))
+
 ## 0.0.2 (2025-10-05)
 
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-kafka-client",
   "displayName": "Kafka Client",
   "description": "Full-featured Kafka client with AWS MSK support, IAM authentication, role assumption, and auto-discovery",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "publisher": "NipunaPerera",
   "license": "GPL-3.0",
   "icon": "resources/kafka-icon.png",


### PR DESCRIPTION
## 🐛 Problem

The `Publish Release` workflow was unable to detect the `AZURE_TOKEN` secret, causing marketplace publishing to be skipped even when the secret was configured.

### Root Cause
GitHub's security prevents direct secret checking in bash conditionals:
```yaml
# ❌ This doesn't work
if [ -n "${{ secrets.AZURE_TOKEN }}" ]; then
```

When secrets are referenced directly in shell commands, GitHub masks them as empty strings for security reasons.

---

## ✅ Solution

Pass the secret through an environment variable first:
```yaml
# ✅ This works
env:
  AZURE_TOKEN: ${{ secrets.AZURE_TOKEN }}
run: |
  if [ -n "$AZURE_TOKEN" ]; then
```

---

## 📝 Changes Made

- Modified `.github/workflows/publish-release.yml`
- Added `env` block to "Check Azure token availability" step
- Secret is now properly detected when configured

---

## 🧪 Testing

Once merged:
- The workflow will detect the `AZURE_TOKEN` secret
- Marketplace publishing will proceed automatically
- Extension v0.0.2 will be published to VS Code Marketplace

---

## 🎯 Impact

- **Fixes**: Marketplace publishing was being skipped despite token being configured
- **Enables**: Automated publishing to VS Code Marketplace
- **No Breaking Changes**: Workflow still safely skips if token is not configured