### PR TITLE
fix: Publish pre-built VSIX to marketplace instead of re-packaging

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -141,7 +141,11 @@ jobs:
       - name: Publish to VS Code Marketplace
         id: marketplace_publish
         if: steps.version_check.outputs.changed == 'true' && steps.check_token.outputs.has_token == 'true'
-        run: vsce publish --pat $VSCE_PAT
+        run: |
+          # Find the VSIX file created by npm run package
+          VSIX_FILE=$(ls *.vsix)
+          echo "Publishing $VSIX_FILE to marketplace..."
+          vsce publish --packagePath "$VSIX_FILE" --pat $VSCE_PAT
         env:
           VSCE_PAT: ${{ secrets.AZURE_TOKEN }}
         continue-on-error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the "Kafka Client" extension will be documented in this f
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.1.2](https://github.com/nipunap/vscode-kafka-client/compare/v0.1.1...v0.1.2) (2025-10-05)
+
+
+### 🐛 Bug Fixes
+
+* Publish pre-built VSIX to marketplace instead of re-packaging ([e31d21f](https://github.com/nipunap/vscode-kafka-client/commit/e31d21fb5d7c64571775c01e644da795d27b336c))
+
 ## [0.1.1](https://github.com/nipunap/vscode-kafka-client/compare/v0.1.0...v0.1.1) (2025-10-05)
 
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-kafka-client",
   "displayName": "Kafka Client",
   "description": "Full-featured Kafka client with AWS MSK support, IAM authentication, role assumption, and auto-discovery",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publisher": "NipunaPerera",
   "license": "GPL-3.0",
   "icon": "resources/kafka-icon.png",


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change

## Problem

The CI publish workflow was failing with:
```
Error: Extension entrypoint(s) missing. Make sure these files exist and aren't ignored by '.vscodeignore':
  extension/out/extension.js
```

**Root Cause:**
- `npm run package` creates bundled VSIX correctly (279 KB, uses dist/extension.js)
- But `vsce publish` tries to **re-package** before publishing
- It fails because `package.json` has `main: ./out/extension.js`
- During bundled builds, `out/` is excluded from the VSIX

## Solution

Use `vsce publish --packagePath` to publish the **existing VSIX** instead of re-packaging.

### Changes

**Before:**
```yaml
- name: Publish to VS Code Marketplace
  run: vsce publish --pat \$VSCE_PAT
```

**After:**
```yaml
- name: Publish to VS Code Marketplace
  run: |
    VSIX_FILE=\$(ls *.vsix)
    echo \"Publishing \$VSIX_FILE to marketplace...\"
    vsce publish --packagePath \"\$VSIX_FILE\" --pat \$VSCE_PAT
```

## Benefits

✅ Publishes the correct bundled version (279 KB)
✅ No entry point conflicts  
✅ Marketplace gets optimized extension
✅ Users download faster, smaller package
✅ No redundant packaging step

## Testing

- [x] Command tested locally
- [x] Will be validated in CI

## Related Issues

Fixes marketplace publishing error in PR #9 follow-up.