### PR TITLE
fix: Make GitHub release creation idempotent

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -112,8 +112,23 @@ jobs:
             git push origin "$VERSION"
           fi
 
-      - name: Create GitHub Release
+      - name: Check if release exists
         if: steps.version_check.outputs.changed == 'true'
+        id: check_release
+        run: |
+          VERSION="v${{ steps.version_check.outputs.version }}"
+          if gh release view "$VERSION" >/dev/null 2>&1; then
+            echo "Release $VERSION already exists"
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "Release $VERSION does not exist"
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create GitHub Release
+        if: steps.version_check.outputs.changed == 'true' && steps.check_release.outputs.exists == 'false'
         uses: softprops/action-gh-release@v1
         with:
           tag_name: v${{ steps.version_check.outputs.version }}
@@ -125,6 +140,12 @@ jobs:
             *.vsix
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Skip release creation
+        if: steps.version_check.outputs.changed == 'true' && steps.check_release.outputs.exists == 'true'
+        run: |
+          echo "⚠️ Release v${{ steps.version_check.outputs.version }} already exists, skipping creation"
+          echo "The VSIX will still be published to the marketplace if configured"
 
       - name: Check Azure token availability
         id: check_token

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the "Kafka Client" extension will be documented in this f
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.1.3](https://github.com/nipunap/vscode-kafka-client/compare/v0.1.2...v0.1.3) (2025-10-05)
+
+
+### 🐛 Bug Fixes
+
+* Make GitHub release creation idempotent ([7482af1](https://github.com/nipunap/vscode-kafka-client/commit/7482af1ae2d08c2466332690b0607a0a83a07fec))
+
 ## [0.1.2](https://github.com/nipunap/vscode-kafka-client/compare/v0.1.1...v0.1.2) (2025-10-05)
 
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-kafka-client",
   "displayName": "Kafka Client",
   "description": "Full-featured Kafka client with AWS MSK support, IAM authentication, role assumption, and auto-discovery",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "publisher": "NipunaPerera",
   "license": "GPL-3.0",
   "icon": "resources/kafka-icon.png",


### PR DESCRIPTION
## Problem

When the CI publish workflow runs multiple times for the same version (e.g., after a manual re-run or when pushing fixes), it fails with:

```
Error: Failed to upload release asset vscode-kafka-client-0.1.2.vsix.
received status code 422
Cannot upload assets to an immutable release.
```

This happened because the workflow tried to create a release that already existed.

## Solution

- Add a `Check if release exists` step that uses `gh release view` to detect existing releases
- Only call `softprops/action-gh-release@v1` if the release does NOT exist
- Add a `Skip release creation` step to log when we skip (for observability)
- Continue with marketplace publishing even if release exists

## Changes

- Added `check_release` step to detect existing releases using GitHub CLI
- Updated `Create GitHub Release` condition to include `&& steps.check_release.outputs.exists == 'false'`
- Added informational step when release already exists

## Testing

This fix makes the workflow **idempotent** - it can be run multiple times safely:

1. First run: Creates release, publishes to marketplace
2. Subsequent runs: Skips release creation, still publishes to marketplace

## Related

- Fixes the `Cannot upload assets to an immutable release` error
- Complements PR #11 (VSIX path fix) for complete CI reliability