### PR TITLE
fix: Remove VSIX from GitHub releases to avoid immutable release error

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -136,8 +136,6 @@ jobs:
           body_path: CHANGELOG.md
           draft: false
           prerelease: false
-          files: |
-            *.vsix
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -208,7 +206,6 @@ jobs:
           echo "### ✅ Completed" >> $GITHUB_STEP_SUMMARY
           echo "- 🏷️ Git tag created" >> $GITHUB_STEP_SUMMARY
           echo "- 📦 GitHub Release created" >> $GITHUB_STEP_SUMMARY
-          echo "- 📤 VSIX package uploaded" >> $GITHUB_STEP_SUMMARY
 
           if [ "${{ steps.check_token.outputs.has_token }}" == "true" ]; then
             if [ "${{ steps.marketplace_publish.outcome }}" == "success" ]; then


### PR DESCRIPTION
## 🐛 Problem

The publish workflow was failing with:
```
Error: Failed to upload release asset vscode-kafka-client-0.1.3.vsix. 
received status code 422
Cannot upload assets to an immutable release.
```

### Root Cause
GitHub releases become **immutable** once published. When the workflow re-runs (e.g., after fixing marketplace publish issues), it attempts to upload the VSIX again to an already-published release, which fails with a 422 error.

---

## ✅ Solution

**Remove VSIX upload from GitHub releases entirely.**

### Why This is Better:
1. ✅ **Primary distribution channel**: VS Code Marketplace (not GitHub releases)
2. ✅ **Prevents 422 errors**: No file upload = no immutable release conflicts
3. ✅ **Simpler workflow**: Release is just a changelog announcement + git tag
4. ✅ **Standard practice**: Most VS Code extensions don't attach VSIX to GitHub releases

### Changes Made:
- Removed `files: | *.vsix` from `softprops/action-gh-release@v1` step
- Updated workflow summary to remove "VSIX package uploaded" line

---

## 🧪 Impact

**Before:**
- ❌ Workflow fails on re-run with 422 error
- ❌ Users confused about where to install from (Marketplace vs GitHub)

**After:**
- ✅ Workflow can re-run without errors
- ✅ Clear distribution: Marketplace only
- ✅ GitHub release is lightweight (just changelog)

---

## 📝 Related

- GitHub Release is still created with changelog
- Git tag is still pushed
- VS Code Marketplace publishing is unaffected