### PR TITLE
fix: Critical regex syntax error breaking webview form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the "Kafka Client" extension will be documented in this f
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.2.1](https://github.com/nipunap/vscode-kafka-client/compare/v0.2.0...v0.2.1) (2025-10-07)
+
+
+### 🐛 Bug Fixes
+
+* regex syntax error in webview causing form to break ([5fe3297](https://github.com/nipunap/vscode-kafka-client/commit/5fe32972e52d258773ff0529ed014e6571ab6a58))
+
 ## [0.2.0](https://github.com/nipunap/vscode-kafka-client/compare/v0.1.4...v0.2.0) (2025-10-06)
 
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-kafka-client",
   "displayName": "Kafka Client",
   "description": "Full-featured Kafka client with AWS MSK support, IAM authentication, role assumption, and auto-discovery",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "publisher": "NipunaPerera",
   "license": "GPL-3.0",
   "icon": "resources/kafka-icon.png",

--- a/src/forms/clusterConnectionWebview.ts
+++ b/src/forms/clusterConnectionWebview.ts
@@ -686,8 +686,9 @@ export class ClusterConnectionWebview {
             const trimmed = broker.trim();
             if (!trimmed) return 'Broker address cannot be empty';
 
-            // Check for dangerous characters
-            if (/[\r\n\0@/?#]/.test(trimmed)) {
+            // Check for dangerous characters (using RegExp constructor to avoid escaping issues)
+            const dangerousChars = new RegExp('[\\\\r\\\\n\\\\0@/?#]');
+            if (dangerousChars.test(trimmed)) {
                 return 'Broker address contains invalid characters';
             }
 
@@ -700,10 +701,10 @@ export class ClusterConnectionWebview {
             const [host, portStr] = parts;
             if (!host || host.length === 0) return 'Host cannot be empty';
 
-            // Validate host format
-            const hostnameRegex = /^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*$/;
-            const ipv4Regex = /^(\d{1,3}\.){3}\d{1,3}$/;
-            const ipv6Regex = /^\[([0-9a-fA-F:]+)\]$/;
+            // Validate host format (using RegExp constructor to avoid escaping issues)
+            const hostnameRegex = new RegExp('^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\\\\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*$');
+            const ipv4Regex = new RegExp('^(\\\\d{1,3}\\\\.){3}\\\\d{1,3}$');
+            const ipv6Regex = new RegExp('^\\\\[([0-9a-fA-F:]+)\\\\]$');
 
             if (!hostnameRegex.test(host) && !ipv4Regex.test(host) && !ipv6Regex.test(host)) {
                 return 'Invalid host format';


### PR DESCRIPTION
## 🐛 Critical Bug Fix

This fixes a **critical regression** that completely broke the cluster connection form.

## Problem

After adding broker URL validation, the webview form stopped working:
- **Error**: `Invalid regular expression: missing /`
- **Impact**: Users couldn't add Apache Kafka or AWS MSK clusters
- **Cause**: Regex literals in HTML template strings were not properly escaped

## Root Cause

When using regex literals inside template strings that get rendered as HTML:
```javascript
// WRONG - breaks in webview
if (/[\r\n\0@/?#]/.test(trimmed)) { ... }
```

The backslashes get interpreted by the template string parser, causing invalid regex syntax when the browser executes `document.write()`.

## Solution

Use `RegExp` constructor instead of regex literals:
```javascript
// CORRECT - works in webview
const dangerousChars = new RegExp('[\\\\r\\\\n\\\\0@/?#]');
if (dangerousChars.test(trimmed)) { ... }
```

## Changes

- ✅ Changed 4 regex patterns to use `RegExp` constructor
- ✅ Proper escaping for template literal context
- ✅ Maintains all security validation logic
- ✅ No breaking changes to validation behavior

## Testing

- ✅ All 132 tests passing
- ✅ Webview loads without errors
- ✅ Form sections show/hide correctly
- ✅ Apache Kafka option works
- ✅ AWS MSK option works
- ✅ Validation still prevents malicious URLs

## Priority

**CRITICAL** - Blocks all new cluster connections. Should be merged immediately.

## Related

- Regression from PR #14 (broker validation security fix)
- Does not affect existing functionality, only new connections