### PR TITLE
fix: resolve security vulnerabilities and improve offset reset robustness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the "Kafka Client" extension will be documented in this f
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.12.7](https://github.com/nipunap/vscode-kafka-client/compare/v0.12.6...v0.12.7) (2026-04-20)
+
+
+### 🐛 Bug Fixes
+
+* resolve security vulnerabilities and improve offset reset robustness ([0d5f07e](https://github.com/nipunap/vscode-kafka-client/commit/0d5f07ed8a42ad01a33449f32f5f079af46ec225))
+
 ## [0.12.6] - 2026-02-16
 
 ### 🐛 Bug Fixes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,114 @@
+# CLAUDE.md - VS Code Kafka Client
+
+## What This Is
+
+A VS Code extension providing a full Kafka client with AWS MSK support, IAM authentication, schema registry integration, and tree-based cluster browsing. Published to both VS Code Marketplace and Open VSX.
+
+## Quick Commands
+
+```bash
+npm run compile          # TypeScript → out/
+npm run compile:strict   # Same + unused vars/params check (runs in pretest)
+npm run lint             # ESLint (flat config, eslint.config.js)
+npm run test             # Full test suite (launches VS Code test host)
+npm run test:unit        # Mocha-only unit tests (no VS Code host)
+npm run bundle           # Production esbuild → dist/extension.js (minified)
+npm run package          # Creates .vsix from dist/ bundle
+npm run watch            # Parallel tsc + esbuild watch
+```
+
+## Architecture
+
+```
+src/
+├── extension.ts              # Entry point: activation, command registration, cleanup
+├── commands/                 # Command handlers grouped by domain
+│   ├── commandRegistry.ts    # Metadata-driven registration (CommandDefinition[])
+│   ├── commandDefinitions.ts # Central list of all 50+ commands
+│   ├── topicCommands.ts      # Topic CRUD, produce, consume, dashboard
+│   ├── consumerGroupCommands.ts
+│   ├── brokerCommands.ts
+│   ├── aclCommands.ts
+│   ├── clusterCommands.ts
+│   └── ...
+├── kafka/
+│   ├── kafkaClientManager.ts # Central facade: connections, pooling, delegation to services
+│   ├── mskIamAuthenticator.ts # AWS IAM token generation with 14-min caching
+│   └── adapters/MSKAdapter.ts # AWS SDK: bootstrap broker discovery from cluster ARN
+├── services/                 # Pure domain logic (no UI deps, fully testable)
+│   ├── TopicService.ts
+│   ├── ConsumerGroupService.ts
+│   ├── BrokerService.ts
+│   ├── ProducerService.ts
+│   ├── PartitionService.ts
+│   ├── SchemaRegistryService.ts # Confluent + AWS Glue schema support
+│   ├── LagMonitor.ts           # Polling-based consumer lag alerts
+│   └── ...
+├── providers/                # VS Code TreeDataProvider implementations
+│   ├── BaseProvider.ts       # Abstract base with error isolation
+│   ├── kafkaExplorerProvider.ts # Clusters → Topics → Partitions tree
+│   ├── consumerGroupProvider.ts
+│   ├── brokerProvider.ts
+│   └── ...
+├── views/                    # Webview panels (HTML-based detail views)
+│   ├── BaseWebview.ts        # Abstract: panel lifecycle, messaging, CSP
+│   ├── DetailsWebview.ts     # Generic details (topics, groups, brokers, ACLs)
+│   ├── MessageConsumerWebview.ts
+│   ├── MessageProducerWebview.ts
+│   └── WebviewManager.ts     # Singleton: prevents duplicates, tracks resources
+├── infrastructure/
+│   ├── Logger.ts             # Per-component loggers, auto-redacts credentials
+│   ├── CredentialManager.ts  # VS Code SecretStorage wrapper (OS keychain)
+│   ├── EventBus.ts           # Pub/sub for decoupling commands ↔ providers
+│   ├── ErrorHandler.ts       # Classifies errors, shows user-friendly messages
+│   ├── ConnectionPool.ts     # Reuses Admin/Producer; 5-min idle timeout
+│   ├── ConfigurationService.ts # Persists cluster metadata to VS Code settings
+│   └── AuditLog.ts           # Operation tracking (no PII)
+├── types/                    # TypeScript interfaces (nodes.ts, acl.ts)
+├── utils/                    # Formatters, validators, error classifiers
+├── forms/                    # Multi-step input wizards (cluster connection)
+└── data/                     # fieldDescriptions.json (Kafka concept tooltips)
+```
+
+### Key Data Flow
+
+- **Operations:** Command → KafkaClientManager → Service → KafkaJS Admin/Producer/Consumer
+- **UI refresh:** Command → EventBus.emit → TreeProvider.refresh → getChildren
+- **Credentials:** CredentialManager (SecretStorage) → KafkaClientManager → KafkaJS/AWS SDK
+
+### Connection Management
+
+`KafkaClientManager` caches Admin/Producer per cluster with 5-min health checks. Auth: PLAINTEXT, SSL, SASL (PLAIN, SCRAM-SHA-256/512, AWS MSK IAM). MSK IAM tokens cached 14 min (15 min expiry).
+
+## Testing
+
+- **Framework:** Mocha (TDD UI) + Sinon stubs. Timeout: 10s.
+- **45 test files** in `src/test/suite/`. Unit tests mock at service boundary. Integration tests (e.g. `*.integration.test.ts`) mock only the KafkaJS `Admin` object.
+- **Pattern:** Command-layer tests stub the manager. Manager-layer tests stub the KafkaJS admin. See `partitionService.integration.test.ts` for the canonical integration test pattern.
+- **Coverage:** `npm run test:coverage` (c8). Thresholds: 30% lines, 50% functions, 70% branches.
+
+## CI/CD
+
+- **ci.yml:** Build + test matrix (ubuntu/windows/macos x Node 18/20), lint, dependency review, VSIX packaging.
+- **auto-version-pr.yml:** Conventional commits on PR → auto semver bump + CHANGELOG update.
+- **publish-release.yml:** On main push with version change → build → GitHub Release → publish to VS Code Marketplace + Open VSX.
+- **codeql.yml:** Weekly security scan.
+
+## Conventions
+
+- **Commits:** Conventional commits (`feat:`, `fix:`, `chore:`, etc.). Breaking changes: `feat!:` or `fix!:`.
+- **Naming:** PascalCase classes, camelCase functions, UPPER_SNAKE_CASE constants/events.
+- **Error handling:** Services throw; commands catch via `ErrorHandler.wrap()`. Providers isolate errors in `getChildrenSafely()`.
+- **Logging:** `private logger = Logger.getLogger('ClassName')`. Credentials auto-redacted.
+- **Imports:** vscode first, then external packages, then relative. No barrel exports.
+- **`any` types:** Allowed by ESLint config (`@typescript-eslint/no-explicit-any: off`), gradually being reduced.
+- **Build outputs:** `out/` for dev/testing, `dist/` for production bundle. Entry point: `out/extension.js`.
+
+## Dependencies Worth Knowing
+
+- `kafkajs` (^2.2.4) — Core Kafka client
+- `@aws-sdk/client-kafka`, `client-sts`, `credential-providers` (^3.990.0) — AWS MSK support
+- `@kafkajs/confluent-schema-registry` (^3.9.0) — Schema validation
+- `aws-msk-iam-sasl-signer-js` — MSK IAM SASL signing
+- `esbuild` — Bundler (not webpack)
+- `commit-and-tag-version` — Release automation

--- a/package-lock.json
+++ b/package-lock.json
@@ -919,13 +919,13 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.4.tgz",
-      "integrity": "sha512-0zJ05ANfYqI6+rGqj8samZBFod0dPPousBjLEqg8WdxSgbMAkRgLyn81lP215Do0rFJ/17LIXwr7q0yK24mP6Q==",
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.18.tgz",
+      "integrity": "sha512-BMDNVG1ETXRhl1tnisQiYBef3RShJ1kfZA7x7afivTFMLirfHNTb6U71K569HNXhSXbQZsweHvSDZ6euBw8hPA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "fast-xml-parser": "5.3.4",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.5.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1632,9 +1632,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1643,9 +1643,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1706,9 +1706,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1723,9 +1723,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1764,9 +1764,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2408,9 +2408,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.12.0.tgz",
-      "integrity": "sha512-9YcuJVTOBDjg9LWo23Qp0lTQ3D7fQsQtwle0jVfpbUHy9qBwCEgKuVH4FqFB3VYu0nwdHKiEMA+oXz7oV8X1kw==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
+      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3182,9 +3182,9 @@
       ]
     },
     "node_modules/@vscode/vsce/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3215,9 +3215,9 @@
       }
     },
     "node_modules/@vscode/vsce/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3636,9 +3636,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4770,9 +4770,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
-      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -4866,9 +4866,9 @@
       }
     },
     "node_modules/dotgitignore/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4904,9 +4904,9 @@
       }
     },
     "node_modules/dotgitignore/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5331,9 +5331,9 @@
       }
     },
     "node_modules/eslint/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5364,9 +5364,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5465,9 +5465,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5598,10 +5598,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-xml-parser": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.4.tgz",
-      "integrity": "sha512-EFd6afGmXlCx8H8WTZHhAoDaWaGyuIBoZJ2mknrNxug+aZKjkp0a0dlars9Izl+jF+7Gu1/5f/2h68cQpe0IiA==",
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
       "funding": [
         {
           "type": "github",
@@ -5610,7 +5610,24 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^2.1.0"
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.5.8",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
+      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.2.0",
+        "strnum": "^2.2.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -5715,16 +5732,16 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true,
       "funding": [
         {
@@ -6257,9 +6274,9 @@
       "license": "ISC"
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6924,6 +6941,16 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
       "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8080,13 +8107,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -8139,29 +8166,30 @@
       "optional": true
     },
     "node_modules/mocha": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.3.0.tgz",
-      "integrity": "sha512-J0RLIM89xi8y6l77bgbX+03PeBRDQCOVQpnwOcCN7b8hCmbh6JvGI2ZDJ5WMoHz+IaPU+S4lvTd0j51GmBAdgQ==",
+      "version": "11.7.5",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.5.tgz",
+      "integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "browser-stdout": "^1.3.1",
         "chokidar": "^4.0.1",
         "debug": "^4.3.5",
-        "diff": "^5.2.0",
+        "diff": "^7.0.0",
         "escape-string-regexp": "^4.0.0",
         "find-up": "^5.0.0",
         "glob": "^10.4.5",
         "he": "^1.2.0",
+        "is-path-inside": "^3.0.3",
         "js-yaml": "^4.1.0",
         "log-symbols": "^4.1.0",
-        "minimatch": "^5.1.6",
+        "minimatch": "^9.0.5",
         "ms": "^2.1.3",
         "picocolors": "^1.1.1",
         "serialize-javascript": "^6.0.2",
         "strip-json-comments": "^3.1.1",
         "supports-color": "^8.1.1",
-        "workerpool": "^6.5.1",
+        "workerpool": "^9.2.0",
         "yargs": "^17.7.2",
         "yargs-parser": "^21.1.1",
         "yargs-unparser": "^2.0.0"
@@ -8195,19 +8223,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/mocha/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/mocha/node_modules/supports-color": {
@@ -8344,9 +8359,9 @@
       }
     },
     "node_modules/npm-run-all/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8372,9 +8387,9 @@
       }
     },
     "node_modules/npm-run-all/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -8871,6 +8886,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -8960,9 +8990,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9051,9 +9081,9 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -10201,9 +10231,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
-      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
       "funding": [
         {
           "type": "github",
@@ -10621,16 +10651,16 @@
       }
     },
     "node_modules/underscore": {
-      "version": "1.13.7",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
-      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
-      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10849,9 +10879,9 @@
       "license": "MIT"
     },
     "node_modules/workerpool": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
-      "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz",
+      "integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -11061,9 +11091,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-kafka-client",
   "displayName": "Kafka Client",
   "description": "Full-featured Kafka client with AWS MSK support, IAM authentication, role assumption, and auto-discovery",
-  "version": "0.12.6",
+  "version": "0.12.7",
   "publisher": "NipunaPerera",
   "license": "GPL-3.0",
   "pricing": "Free",

--- a/src/kafka/kafkaClientManager.ts
+++ b/src/kafka/kafkaClientManager.ts
@@ -633,13 +633,30 @@ export class KafkaClientManager {
     ) {
         const admin = await this.getAdmin(clusterName);
 
+        // Validate specific offset before any network calls
+        if (resetTo === 'specific offset') {
+            const offsetNum = parseInt(specificOffset ?? '', 10);
+            if (!specificOffset || isNaN(offsetNum) || offsetNum < 0) {
+                throw new Error(`Invalid offset value: "${specificOffset}". Must be a non-negative integer.`);
+            }
+        }
+
         // Get topics for the consumer group if not specified
         let topics: string[] = [];
         if (topic) {
             topics = [topic];
         } else {
             const offsets = await admin.fetchOffsets({ groupId });
-            topics = [...new Set(offsets.map((o: any) => o.topic))];
+            const validTopics = offsets.map((o: any) => o.topic).filter(Boolean);
+            const dropped = offsets.length - validTopics.length;
+            if (dropped > 0) {
+                this.logger.warn(`resetConsumerGroupOffsets: dropped ${dropped} offset entries with undefined topic for group "${groupId}"`);
+            }
+            topics = [...new Set(validTopics)];
+        }
+
+        if (topics.length === 0) {
+            throw new Error(`Consumer group "${groupId}" has no committed topic offsets to reset`);
         }
 
         // Build reset spec for each topic
@@ -651,8 +668,11 @@ export class KafkaClientManager {
         for (const topicName of topics) {
             const topicOffsets = await admin.fetchTopicOffsets(topicName);
             const partitions = topicOffsets.map((p: any) => {
-                let offset: string;
+                if (p.low === undefined || p.low === null || p.high === undefined || p.high === null) {
+                    throw new Error(`Missing offset bounds for partition ${p.partition} on topic "${topicName}"`);
+                }
 
+                let offset: string;
                 if (resetTo === 'beginning') {
                     offset = p.low;
                 } else if (resetTo === 'end') {

--- a/src/services/ConsumerGroupService.ts
+++ b/src/services/ConsumerGroupService.ts
@@ -101,45 +101,6 @@ export class ConsumerGroupService {
     }
 
     /**
-     * Reset consumer group offsets
-     */
-    async resetConsumerGroupOffsets(
-        admin: Admin,
-        groupId: string,
-        topic: string,
-        offset: 'earliest' | 'latest' | number
-    ): Promise<void> {
-        try {
-            this.logger.info(`Resetting offsets for consumer group: ${groupId}, topic: ${topic}, offset: ${offset}`);
-
-            // First, get topic metadata to know partition count
-            const metadata = await admin.fetchTopicMetadata({ topics: [topic] });
-            const topicMetadata = metadata.topics.find(t => t.name === topic);
-
-            if (!topicMetadata) {
-                throw new Error(`Topic not found: ${topic}`);
-            }
-
-            // Build offset reset structure
-            const partitions = topicMetadata.partitions.map(p => ({
-                partition: p.partitionId,
-                offset: offset === 'earliest' ? '0' : offset === 'latest' ? '-1' : String(offset)
-            }));
-
-            await admin.setOffsets({
-                groupId,
-                topic,
-                partitions
-            });
-
-            this.logger.info(`Successfully reset offsets for consumer group: ${groupId}`);
-        } catch (error) {
-            this.logger.error(`Failed to reset offsets for consumer group: ${groupId}`, error);
-            throw error;
-        }
-    }
-
-    /**
      * Get comprehensive consumer group info (details + offsets)
      */
     async getConsumerGroupInfo(admin: Admin, groupId: string): Promise<any> {

--- a/src/test/suite/kafkaClientManager.resetConsumerGroupOffsets.integration.test.ts
+++ b/src/test/suite/kafkaClientManager.resetConsumerGroupOffsets.integration.test.ts
@@ -1,0 +1,218 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { KafkaClientManager } from '../../kafka/kafkaClientManager';
+import { Admin } from 'kafkajs';
+
+suite('KafkaClientManager.resetConsumerGroupOffsets Integration Tests', () => {
+    let manager: KafkaClientManager;
+    let mockAdmin: sinon.SinonStubbedInstance<Admin>;
+    let sandbox: sinon.SinonSandbox;
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        manager = new KafkaClientManager();
+        mockAdmin = {
+            fetchOffsets: sandbox.stub(),
+            fetchTopicOffsets: sandbox.stub(),
+            resetOffsets: sandbox.stub()
+        } as any;
+
+        // Bypass getAdmin (private) to inject our mock
+        sandbox.stub(manager as any, 'getAdmin').resolves(mockAdmin);
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
+    // --- Topic filtering ---
+
+    suite('Topic filtering from fetchOffsets', () => {
+        test('should drop entries with undefined topic and continue with valid ones', async () => {
+            (mockAdmin.fetchOffsets as sinon.SinonStub).resolves([
+                { topic: 'valid-topic', partition: 0 },
+                { topic: undefined, partition: 1 }
+            ]);
+            (mockAdmin.fetchTopicOffsets as sinon.SinonStub).resolves([
+                { partition: 0, low: '0', high: '100' }
+            ]);
+            (mockAdmin.resetOffsets as sinon.SinonStub).resolves();
+
+            await manager.resetConsumerGroupOffsets('cluster', 'group1');
+
+            assert.strictEqual((mockAdmin.fetchTopicOffsets as sinon.SinonStub).callCount, 1);
+            assert.strictEqual((mockAdmin.fetchTopicOffsets as sinon.SinonStub).firstCall.args[0], 'valid-topic');
+            assert.ok((mockAdmin.resetOffsets as sinon.SinonStub).calledOnce);
+        });
+
+        test('should drop entries with null topic and continue with valid ones', async () => {
+            (mockAdmin.fetchOffsets as sinon.SinonStub).resolves([
+                { topic: 'my-topic', partition: 0 },
+                { topic: null, partition: 1 }
+            ]);
+            (mockAdmin.fetchTopicOffsets as sinon.SinonStub).resolves([
+                { partition: 0, low: '5', high: '50' }
+            ]);
+            (mockAdmin.resetOffsets as sinon.SinonStub).resolves();
+
+            await manager.resetConsumerGroupOffsets('cluster', 'group1');
+
+            assert.strictEqual((mockAdmin.fetchTopicOffsets as sinon.SinonStub).firstCall.args[0], 'my-topic');
+        });
+
+        test('should throw when all topics are filtered out', async () => {
+            (mockAdmin.fetchOffsets as sinon.SinonStub).resolves([
+                { topic: undefined, partition: 0 },
+                { topic: null, partition: 1 }
+            ]);
+
+            await assert.rejects(
+                () => manager.resetConsumerGroupOffsets('cluster', 'group1'),
+                /has no committed topic offsets to reset/
+            );
+            assert.ok((mockAdmin.resetOffsets as sinon.SinonStub).notCalled);
+        });
+
+        test('should throw when fetchOffsets returns an empty array', async () => {
+            (mockAdmin.fetchOffsets as sinon.SinonStub).resolves([]);
+
+            await assert.rejects(
+                () => manager.resetConsumerGroupOffsets('cluster', 'group1'),
+                /has no committed topic offsets to reset/
+            );
+            assert.ok((mockAdmin.resetOffsets as sinon.SinonStub).notCalled);
+        });
+    });
+
+    // --- Partition bounds validation ---
+
+    suite('Partition bounds validation', () => {
+        setup(() => {
+            (mockAdmin.fetchOffsets as sinon.SinonStub).resolves([
+                { topic: 'test-topic', partition: 0 }
+            ]);
+        });
+
+        test('should throw when p.low is null', async () => {
+            (mockAdmin.fetchTopicOffsets as sinon.SinonStub).resolves([
+                { partition: 0, low: null, high: '100' }
+            ]);
+
+            await assert.rejects(
+                () => manager.resetConsumerGroupOffsets('cluster', 'group1', undefined, 'beginning'),
+                /Missing offset bounds for partition 0 on topic "test-topic"/
+            );
+        });
+
+        test('should throw when p.high is undefined', async () => {
+            (mockAdmin.fetchTopicOffsets as sinon.SinonStub).resolves([
+                { partition: 0, low: '0', high: undefined }
+            ]);
+
+            await assert.rejects(
+                () => manager.resetConsumerGroupOffsets('cluster', 'group1', undefined, 'end'),
+                /Missing offset bounds for partition 0 on topic "test-topic"/
+            );
+        });
+    });
+
+    // --- Specific offset validation ---
+
+    suite('Specific offset validation', () => {
+        test('should reject a negative specific offset', async () => {
+            await assert.rejects(
+                () => manager.resetConsumerGroupOffsets('cluster', 'group1', 'topic', 'specific offset', '-1'),
+                /Invalid offset value/
+            );
+            assert.ok((mockAdmin.fetchOffsets as sinon.SinonStub).notCalled);
+        });
+
+        test('should reject a non-numeric specific offset', async () => {
+            await assert.rejects(
+                () => manager.resetConsumerGroupOffsets('cluster', 'group1', 'topic', 'specific offset', 'abc'),
+                /Invalid offset value/
+            );
+        });
+
+        test('should reject a missing specific offset when strategy is "specific offset"', async () => {
+            await assert.rejects(
+                () => manager.resetConsumerGroupOffsets('cluster', 'group1', 'topic', 'specific offset', undefined),
+                /Invalid offset value/
+            );
+        });
+
+        test('should accept a valid specific offset and pass it to resetOffsets', async () => {
+            (mockAdmin.fetchTopicOffsets as sinon.SinonStub).resolves([
+                { partition: 0, low: '0', high: '200' }
+            ]);
+            (mockAdmin.resetOffsets as sinon.SinonStub).resolves();
+
+            await manager.resetConsumerGroupOffsets('cluster', 'group1', 'topic', 'specific offset', '42');
+
+            const resetCall = (mockAdmin.resetOffsets as sinon.SinonStub).firstCall.args[0];
+            assert.strictEqual(resetCall.topics[0].partitions[0].offset, '42');
+        });
+    });
+
+    // --- Happy path ---
+
+    suite('Happy path', () => {
+        test('should reset multiple topics and partitions to beginning', async () => {
+            (mockAdmin.fetchOffsets as sinon.SinonStub).resolves([
+                { topic: 'topic-a', partition: 0 },
+                { topic: 'topic-b', partition: 0 }
+            ]);
+            (mockAdmin.fetchTopicOffsets as sinon.SinonStub)
+                .withArgs('topic-a').resolves([
+                    { partition: 0, low: '10', high: '100' },
+                    { partition: 1, low: '5', high: '50' }
+                ])
+                .withArgs('topic-b').resolves([
+                    { partition: 0, low: '0', high: '200' }
+                ]);
+            (mockAdmin.resetOffsets as sinon.SinonStub).resolves();
+
+            await manager.resetConsumerGroupOffsets('cluster', 'group1', undefined, 'beginning');
+
+            assert.ok((mockAdmin.resetOffsets as sinon.SinonStub).calledOnce);
+            const spec = (mockAdmin.resetOffsets as sinon.SinonStub).firstCall.args[0];
+            assert.strictEqual(spec.groupId, 'group1');
+            assert.strictEqual(spec.topics.length, 2);
+
+            const topicA = spec.topics.find((t: any) => t.topic === 'topic-a');
+            assert.strictEqual(topicA.partitions[0].offset, '10'); // low
+            assert.strictEqual(topicA.partitions[1].offset, '5');  // low
+
+            const topicB = spec.topics.find((t: any) => t.topic === 'topic-b');
+            assert.strictEqual(topicB.partitions[0].offset, '0'); // low
+        });
+
+        test('should reset to end (high watermark)', async () => {
+            (mockAdmin.fetchOffsets as sinon.SinonStub).resolves([
+                { topic: 'topic-a', partition: 0 }
+            ]);
+            (mockAdmin.fetchTopicOffsets as sinon.SinonStub).resolves([
+                { partition: 0, low: '0', high: '999' }
+            ]);
+            (mockAdmin.resetOffsets as sinon.SinonStub).resolves();
+
+            await manager.resetConsumerGroupOffsets('cluster', 'group1', undefined, 'end');
+
+            const spec = (mockAdmin.resetOffsets as sinon.SinonStub).firstCall.args[0];
+            assert.strictEqual(spec.topics[0].partitions[0].offset, '999');
+        });
+
+        test('should use specific topic when provided (skipping fetchOffsets)', async () => {
+            (mockAdmin.fetchTopicOffsets as sinon.SinonStub).resolves([
+                { partition: 0, low: '0', high: '50' }
+            ]);
+            (mockAdmin.resetOffsets as sinon.SinonStub).resolves();
+
+            await manager.resetConsumerGroupOffsets('cluster', 'group1', 'explicit-topic', 'beginning');
+
+            assert.ok((mockAdmin.fetchOffsets as sinon.SinonStub).notCalled);
+            const spec = (mockAdmin.resetOffsets as sinon.SinonStub).firstCall.args[0];
+            assert.strictEqual(spec.topics[0].topic, 'explicit-topic');
+        });
+    });
+});


### PR DESCRIPTION
### Summary

- Upgraded dependencies to resolve security vulnerabilities flagged in package-lock.json
- Moved resetConsumerGroupOffsets logic fully into KafkaClientManager, removing the duplicate implementation from ConsumerGroupService
- Added upfront validation for specific offset input (must be a non-negative integer) before any network calls
- Guard against undefined/empty topics returned by fetchOffsets, with a warning log for dropped entries
- Throw a clear error when a group has no committed offsets to reset
- Validate that partition offset bounds exist before attempting a reset