### PR TITLE
fix: upgrade GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/auto-version-pr.yml
+++ b/.github/workflows/auto-version-pr.yml
@@ -23,14 +23,14 @@ jobs:
       
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20.x'
           cache: 'npm'

--- a/.github/workflows/auto-version-pr.yml
+++ b/.github/workflows/auto-version-pr.yml
@@ -130,7 +130,7 @@ jobs:
       
       - name: Comment on PR
         if: steps.version_bump.outputs.bump_type != 'none' && steps.check_bumped.outputs.already_bumped == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             github.rest.issues.createComment({

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -122,7 +122,7 @@ jobs:
 
       - name: Upload compilation artifacts
         if: matrix.os == 'ubuntu-latest' && matrix.node-version == '20.x'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: compiled-extension
           path: out/
@@ -139,10 +139,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20.x'
           cache: 'npm'
@@ -176,7 +176,7 @@ jobs:
 
       - name: Upload VSIX
         if: steps.check_package.outputs.package_success == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: vsix-package
           path: '*.vsix'
@@ -192,10 +192,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20.x'
           cache: 'npm'
@@ -217,7 +217,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Dependency Review
         uses: actions/dependency-review-action@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Full history for tag comparison
 
@@ -113,7 +113,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -141,10 +141,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20.x'
           cache: 'npm'
@@ -234,7 +234,7 @@ jobs:
           echo "vsix_size=$FILE_SIZE" >> $GITHUB_OUTPUT
 
       - name: Upload VSIX artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: vscode-kafka-${{ needs.version-check.outputs.version }}.vsix
           path: '*.vsix'
@@ -252,10 +252,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download VSIX artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: vscode-kafka-${{ needs.version-check.outputs.version }}.vsix
 
@@ -312,7 +312,7 @@ jobs:
 
     steps:
       - name: Download VSIX artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: vscode-kafka-${{ needs.version-check.outputs.version }}.vsix
 
@@ -401,7 +401,7 @@ jobs:
 
     steps:
       - name: Download VSIX artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: vscode-kafka-${{ needs.version-check.outputs.version }}.vsix
 
@@ -418,7 +418,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.check_token.outputs.has_token == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20.x'
 
@@ -496,7 +496,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check if both publishes failed
         id: check_failure

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -358,7 +358,7 @@ jobs:
 
       - name: Report marketplace publish failure
         if: steps.check_token.outputs.has_token == 'true' && steps.publish.outcome == 'failure'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         continue-on-error: true
         with:
           script: |
@@ -449,7 +449,7 @@ jobs:
 
       - name: Report Open VSX publish failure
         if: steps.check_token.outputs.has_token == 'true' && steps.publish.outcome == 'failure'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         continue-on-error: true
         with:
           script: |
@@ -515,7 +515,7 @@ jobs:
 
       - name: Create rollback issue (manual decision)
         if: steps.check_failure.outputs.should_rollback == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.issues.create({

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the "Kafka Client" extension will be documented in this f
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.12.8](https://github.com/nipunap/vscode-kafka-client/compare/v0.12.7...v0.12.8) (2026-04-20)
+
+
+### 🐛 Bug Fixes
+
+* upgrade actions/github-script to v9 ([d0a913a](https://github.com/nipunap/vscode-kafka-client/commit/d0a913a4c1b461ee4587798230614cdfe7ecf4b5))
+* upgrade GitHub Actions to Node.js 24 compatible versions ([507e90f](https://github.com/nipunap/vscode-kafka-client/commit/507e90ff8aca2aa0318c11653cf2d00dc4da6b30))
+
 ## [0.12.7](https://github.com/nipunap/vscode-kafka-client/compare/v0.12.6...v0.12.7) (2026-04-20)
 
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-kafka-client",
   "displayName": "Kafka Client",
   "description": "Full-featured Kafka client with AWS MSK support, IAM authentication, role assumption, and auto-discovery",
-  "version": "0.12.7",
+  "version": "0.12.8",
   "publisher": "NipunaPerera",
   "license": "GPL-3.0",
   "pricing": "Free",


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout` and `actions/setup-node` to v6
- Bumps `actions/upload-artifact` to v7
- Bumps `actions/download-artifact` to v8

Resolves Node.js 20 deprecation warnings and fixes `download-artifact@v4` SHA resolution failures breaking the publish workflow on `main`.

## Test plan
- [ ] Verify CI workflow passes on this PR
- [ ] Verify publish workflow can resolve all action downloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)