### PR TITLE
fix: resolve AI model detection and empty tree view UX issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the "Kafka Client" extension will be documented in this f
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.12.9](https://github.com/nipunap/vscode-kafka-client/compare/v0.12.8...v0.12.9) (2026-04-20)
+
+
+### 🐛 Bug Fixes
+
+* resolve AI model detection and empty tree view UX issues ([32b1d20](https://github.com/nipunap/vscode-kafka-client/commit/32b1d202fcf569b071c29d37b6786846c7962b70))
+
 ## [0.12.8](https://github.com/nipunap/vscode-kafka-client/compare/v0.12.7...v0.12.8) (2026-04-20)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-kafka-client",
-  "version": "0.12.6",
+  "version": "0.12.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-kafka-client",
-      "version": "0.12.6",
+      "version": "0.12.8",
       "license": "GPL-3.0",
       "dependencies": {
         "@aws-sdk/client-kafka": "^3.990.0",
@@ -36,6 +36,7 @@
         "npm-run-all": "^4.1.5",
         "ovsx": "^0.8.3",
         "sinon": "^21.0.0",
+        "ts-node": "^10.9.2",
         "typescript": "^5.7.2"
       },
       "engines": {
@@ -1143,6 +1144,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2638,6 +2663,34 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/buffers": {
       "version": "0.1.31",
       "resolved": "https://registry.npmjs.org/@types/buffers/-/buffers-0.1.31.tgz",
@@ -3250,6 +3303,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/add-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
@@ -3308,6 +3374,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -4437,6 +4510,13 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -7766,6 +7846,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/map-obj": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
@@ -8223,19 +8310,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/mocha/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/mocha/node_modules/supports-color": {
@@ -10446,6 +10520,60 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -10718,6 +10846,13 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -11264,6 +11399,16 @@
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4850,9 +4850,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
-      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -9238,16 +9238,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -9703,13 +9693,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/set-function-length": {
@@ -9958,16 +9948,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/sinon"
-      }
-    },
-    "node_modules/sinon/node_modules/diff": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
-      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "node_modules/sinon/node_modules/has-flag": {
@@ -10562,16 +10542,6 @@
         "@swc/wasm": {
           "optional": true
         }
-      }
-    },
-    "node_modules/ts-node/node_modules/diff": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
-      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -656,6 +656,10 @@
     "release:minor": "commit-and-tag-version --release-as minor",
     "release:patch": "commit-and-tag-version --release-as patch"
   },
+  "overrides": {
+    "serialize-javascript": "7.0.5",
+    "diff": "8.0.3"
+  },
   "devDependencies": {
     "@types/ini": "^4.1.1",
     "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -40,14 +40,6 @@
     "color": "#231F20",
     "theme": "dark"
   },
-  "activationEvents": [
-    "onView:kafkaExplorer",
-    "onView:kafkaConsumerGroups",
-    "onView:kafkaBrokers",
-    "onView:kafkaStreams",
-    "onView:kafkaTables",
-    "onCommand:kafka.addCluster"
-  ],
   "main": "./out/extension.js",
   "contributes": {
     "viewsContainers": {
@@ -59,6 +51,28 @@
         }
       ]
     },
+    "viewsWelcome": [
+      {
+        "view": "kafkaExplorer",
+        "contents": "No Kafka clusters configured.\n[Add Cluster](command:kafka.addCluster)\nYou can also run the **Add Cluster** command from the Command Palette."
+      },
+      {
+        "view": "kafkaConsumerGroups",
+        "contents": "No Kafka clusters configured.\n[Add Cluster](command:kafka.addCluster)"
+      },
+      {
+        "view": "kafkaBrokers",
+        "contents": "No Kafka clusters configured.\n[Add Cluster](command:kafka.addCluster)"
+      },
+      {
+        "view": "kafkaStreams",
+        "contents": "No Kafka clusters configured.\n[Add Cluster](command:kafka.addCluster)"
+      },
+      {
+        "view": "kafkaTables",
+        "contents": "No Kafka clusters configured.\n[Add Cluster](command:kafka.addCluster)"
+      }
+    ],
     "views": {
       "kafka-explorer": [
         {
@@ -660,6 +674,7 @@
     "npm-run-all": "^4.1.5",
     "ovsx": "^0.8.3",
     "sinon": "^21.0.0",
+    "ts-node": "^10.9.2",
     "typescript": "^5.7.2"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-kafka-client",
   "displayName": "Kafka Client",
   "description": "Full-featured Kafka client with AWS MSK support, IAM authentication, role assumption, and auto-discovery",
-  "version": "0.12.8",
+  "version": "0.12.9",
   "publisher": "NipunaPerera",
   "license": "GPL-3.0",
   "pricing": "Free",

--- a/src/commands/consumerGroupCommands.ts
+++ b/src/commands/consumerGroupCommands.ts
@@ -6,6 +6,7 @@ import * as vscode from 'vscode';
 import { KafkaClientManager } from '../kafka/kafkaClientManager';
 import { DetailsWebview, DetailsData } from '../views/DetailsWebview';
 import { ErrorHandler } from '../infrastructure/ErrorHandler';
+import { AIAdvisor } from '../services/AIAdvisor';
 
 export async function showConsumerGroupDetails(clientManager: KafkaClientManager, node: any, context?: vscode.ExtensionContext) {
     await ErrorHandler.wrap(async () => {
@@ -38,6 +39,9 @@ export async function showConsumerGroupDetails(clientManager: KafkaClientManager
         // Create HTML view
         const detailsView = new DetailsWebview(`Consumer Group: ${node.groupId}`, '👥', context);
 
+        // Check if AI features are available
+        const aiAvailable = await AIAdvisor.checkAvailability();
+
         // Get state badge
         const getStateBadge = (state: string) => {
             const stateUpper = state.toUpperCase();
@@ -51,6 +55,7 @@ export async function showConsumerGroupDetails(clientManager: KafkaClientManager
             title: node.groupId,
             showCopyButton: true,
             showRefreshButton: false,
+            showAIAdvisor: aiAvailable,
             notice: {
                 type: 'info',
                 text: '✏️ Edit mode coming soon! You\'ll be able to reset offsets and modify group settings directly from this view.'
@@ -122,6 +127,20 @@ export async function showConsumerGroupDetails(clientManager: KafkaClientManager
                 }
             ]
         };
+
+        // Set up AI request handler only if AI is available
+        if (aiAvailable) {
+            detailsView.setAIRequestHandler(async () => {
+                const recommendations = await AIAdvisor.analyzeConsumerGroup({
+                    groupId: details.groupId || node.groupId,
+                    state: details.state || 'Unknown',
+                    members: details.members?.length || 0,
+                    totalLag: details.totalLag || 0,
+                    topics: Array.from(new Set<string>((details.offsets || []).map((o: any) => o.topic).filter(Boolean)))
+                });
+                detailsView.updateWithAIRecommendations(recommendations);
+            });
+        }
 
         detailsView.showDetails(data);
     }, `Loading consumer group details for "${node.groupId}"`);

--- a/src/providers/brokerProvider.ts
+++ b/src/providers/brokerProvider.ts
@@ -13,7 +13,7 @@ export class BrokerProvider extends BaseProvider<BrokerTreeItem> {
             const clusters = this.getClusters();
 
             if (clusters.length === 0) {
-                return [this.createEmptyItem('No clusters configured.') as BrokerTreeItem];
+                return [];
             }
 
             return clusters.map(

--- a/src/providers/consumerGroupProvider.ts
+++ b/src/providers/consumerGroupProvider.ts
@@ -14,7 +14,7 @@ export class ConsumerGroupProvider extends BaseProvider<ConsumerGroupTreeItem> {
             const clusters = this.getClusters();
 
             if (clusters.length === 0) {
-                return [this.createEmptyItem('No clusters configured.') as ConsumerGroupTreeItem];
+                return [];
             }
 
             return clusters.map(

--- a/src/providers/kafkaExplorerProvider.ts
+++ b/src/providers/kafkaExplorerProvider.ts
@@ -80,7 +80,7 @@ export class KafkaExplorerProvider extends BaseProvider<KafkaTreeItem> {
             const clusters = this.getClusters();
 
             if (clusters.length === 0) {
-                return [this.createEmptyItem('No clusters configured. Click + to add one.') as KafkaTreeItem];
+                return [];
             }
 
             return clusters.map(

--- a/src/providers/kstreamProvider.ts
+++ b/src/providers/kstreamProvider.ts
@@ -17,7 +17,7 @@ export class KStreamProvider extends BaseProvider<KStreamTreeItem> {
             const clusters = this.getClusters();
 
             if (clusters.length === 0) {
-                return [this.createEmptyItem('No clusters configured.') as KStreamTreeItem];
+                return [];
             }
 
             return clusters.map(

--- a/src/providers/ktableProvider.ts
+++ b/src/providers/ktableProvider.ts
@@ -17,7 +17,7 @@ export class KTableProvider extends BaseProvider<KTableTreeItem> {
             const clusters = this.getClusters();
 
             if (clusters.length === 0) {
-                return [this.createEmptyItem('No clusters configured.') as KTableTreeItem];
+                return [];
             }
 
             return clusters.map(

--- a/src/services/AIAdvisor.ts
+++ b/src/services/AIAdvisor.ts
@@ -8,6 +8,7 @@ import { Logger } from '../infrastructure/Logger';
 export class AIAdvisor {
     private static logger = Logger.getLogger('AIAdvisor');
     private static isAvailable: boolean | undefined;
+    private static cachedModels: vscode.LanguageModelChat[] | undefined;
 
     /**
      * Check if AI/LLM features are available
@@ -18,32 +19,37 @@ export class AIAdvisor {
         }
 
         try {
-            // Check if the Language Model API is available
-            const models = await vscode.lm.selectChatModels({
-                vendor: 'copilot',
-                family: 'gpt-4'
-            });
+            const models = await vscode.lm.selectChatModels({});
 
-            // Also check for gpt-3.5-turbo as fallback
-            const fallbackModels = await vscode.lm.selectChatModels({
-                vendor: 'copilot',
-                family: 'gpt-3.5-turbo'
-            });
-
-            this.isAvailable = models.length > 0 || fallbackModels.length > 0;
-
-            if (this.isAvailable) {
+            if (models.length > 0) {
+                this.isAvailable = true;
+                this.cachedModels = models;
                 this.logger.info('AI Advisor features are available');
             } else {
+                this.isAvailable = undefined; // don't cache false — Copilot may still be initialising; retry on next user action
+                this.cachedModels = undefined;
                 this.logger.info('AI Advisor features not available - GitHub Copilot may not be active');
             }
 
-            return this.isAvailable;
+            return this.isAvailable ?? false;
         } catch (error) {
             this.logger.debug('Language Model API not available', error);
             this.isAvailable = false;
             return false;
         }
+    }
+
+    private static async resolveModel(): Promise<vscode.LanguageModelChat> {
+        if (this.cachedModels && this.cachedModels.length > 0) {
+            return this.cachedModels[0];
+        }
+        const models = await vscode.lm.selectChatModels({});
+        const model = models[0];
+        if (!model) {
+            throw new Error('No AI models available');
+        }
+        this.cachedModels = models;
+        return model;
     }
 
     /**
@@ -62,23 +68,8 @@ export class AIAdvisor {
         }
 
         try {
-            const models = await vscode.lm.selectChatModels({
-                vendor: 'copilot',
-                family: 'gpt-4'
-            });
+            const model = await AIAdvisor.resolveModel();
 
-            if (models.length === 0) {
-                // Fallback to GPT-3.5
-                const fallbackModels = await vscode.lm.selectChatModels({
-                    vendor: 'copilot',
-                    family: 'gpt-3.5-turbo'
-                });
-                if (fallbackModels.length === 0) {
-                    throw new Error('No AI models available');
-                }
-            }
-
-            const model = models[0];
             const messages = [
                 vscode.LanguageModelChatMessage.User(`You are a Kafka expert consultant. Analyze this topic and provide CONCISE, actionable recommendations.
 
@@ -125,6 +116,7 @@ Keep each bullet point to ONE LINE. Be specific with numbers and settings. No fl
 
             return response || 'Unable to generate recommendations at this time.';
         } catch (error: any) {
+            AIAdvisor.cachedModels = undefined;
             this.logger.error('Failed to get AI recommendations', error);
             throw new Error(`AI analysis failed: ${error.message}`);
         }
@@ -145,22 +137,8 @@ Keep each bullet point to ONE LINE. Be specific with numbers and settings. No fl
         }
 
         try {
-            const models = await vscode.lm.selectChatModels({
-                vendor: 'copilot',
-                family: 'gpt-4'
-            });
+            const model = await AIAdvisor.resolveModel();
 
-            if (models.length === 0) {
-                const fallbackModels = await vscode.lm.selectChatModels({
-                    vendor: 'copilot',
-                    family: 'gpt-3.5-turbo'
-                });
-                if (fallbackModels.length === 0) {
-                    throw new Error('No AI models available');
-                }
-            }
-
-            const model = models[0];
             const messages = [
                 vscode.LanguageModelChatMessage.User(`You are a Kafka expert consultant. Analyze this broker and provide CONCISE, actionable recommendations.
 
@@ -208,6 +186,7 @@ Keep each bullet to ONE LINE. Be specific with numbers. No fluff.`)
 
             return response || 'Unable to generate recommendations at this time.';
         } catch (error: any) {
+            AIAdvisor.cachedModels = undefined;
             this.logger.error('Failed to get AI recommendations', error);
             throw new Error(`AI analysis failed: ${error.message}`);
         }
@@ -229,22 +208,8 @@ Keep each bullet to ONE LINE. Be specific with numbers. No fluff.`)
         }
 
         try {
-            const models = await vscode.lm.selectChatModels({
-                vendor: 'copilot',
-                family: 'gpt-4'
-            });
+            const model = await AIAdvisor.resolveModel();
 
-            if (models.length === 0) {
-                const fallbackModels = await vscode.lm.selectChatModels({
-                    vendor: 'copilot',
-                    family: 'gpt-3.5-turbo'
-                });
-                if (fallbackModels.length === 0) {
-                    throw new Error('No AI models available');
-                }
-            }
-
-            const model = models[0];
             const messages = [
                 vscode.LanguageModelChatMessage.User(`You are a Kafka expert consultant. Analyze this consumer group and provide CONCISE, actionable recommendations.
 
@@ -288,6 +253,7 @@ Keep each bullet to ONE LINE. Be specific with numbers. No fluff.`)
 
             return response || 'Unable to generate recommendations at this time.';
         } catch (error: any) {
+            AIAdvisor.cachedModels = undefined;
             this.logger.error('Failed to get AI recommendations', error);
             throw new Error(`AI analysis failed: ${error.message}`);
         }
@@ -303,22 +269,7 @@ Keep each bullet to ONE LINE. Be specific with numbers. No fluff.`)
         }
 
         try {
-            const models = await vscode.lm.selectChatModels({
-                vendor: 'copilot',
-                family: 'gpt-4'
-            });
-
-            if (models.length === 0) {
-                const fallbackModels = await vscode.lm.selectChatModels({
-                    vendor: 'copilot',
-                    family: 'gpt-3.5-turbo'
-                });
-                if (fallbackModels.length === 0) {
-                    throw new Error('No AI models available');
-                }
-            }
-
-            const model = models[0];
+            const model = await AIAdvisor.resolveModel();
 
             const contextMessage = context ? `\n\n**Context:**\n${context}` : '';
 
@@ -344,6 +295,7 @@ Keep each bullet to ONE LINE. Be specific with numbers. No fluff.`)
 
             return response || 'Unable to generate an answer at this time.';
         } catch (error: any) {
+            AIAdvisor.cachedModels = undefined;
             this.logger.error('Failed to get AI answer', error);
             throw new Error(`AI query failed: ${error.message}`);
         }

--- a/src/services/parameterAIService.ts
+++ b/src/services/parameterAIService.ts
@@ -85,15 +85,8 @@ export class ParameterAIService {
      * Fetch response from AI model
      */
     private async fetchAIResponse(parameterName: string): Promise<string> {
-        const models = await vscode.lm.selectChatModels({
-            vendor: 'copilot',
-            family: 'gpt-4'
-        });
-
-        const model = models[0] || (await vscode.lm.selectChatModels({
-            vendor: 'copilot',
-            family: 'gpt-3.5-turbo'
-        }))[0];
+        const models = await vscode.lm.selectChatModels({});
+        const model = models[0];
 
         if (!model) {
             throw new Error('No AI model available');

--- a/src/test/suite/brokerProvider.test.ts
+++ b/src/test/suite/brokerProvider.test.ts
@@ -37,9 +37,7 @@ suite('Broker Provider Test Suite', () => {
         test('should return empty array when no clusters', async () => {
             const children = await provider.getChildren();
             assert.strictEqual(Array.isArray(children), true);
-            // Now returns 1 item with helpful "No clusters configured." message
-            assert.strictEqual(children.length, 1);
-            assert.strictEqual(children[0].contextValue, 'empty');
+            assert.strictEqual(children.length, 0);
         });
 
         test('should have onDidChangeTreeData event', () => {

--- a/src/test/suite/kstreamProvider.test.ts
+++ b/src/test/suite/kstreamProvider.test.ts
@@ -25,14 +25,12 @@ suite('KStream Provider Test Suite', () => {
     });
 
     suite('Root Level', () => {
-        test('should return empty state when no clusters configured', async () => {
+        test('should return empty array when no clusters configured', async () => {
             getClustersStub.returns([]);
 
             const children = await provider.getChildren();
 
-            assert.strictEqual(children.length, 1);
-            assert.strictEqual(children[0].label, 'No clusters configured.');
-            assert.strictEqual(children[0].contextValue, 'empty');
+            assert.strictEqual(children.length, 0);
         });
 
         test('should return cluster items when clusters exist', async () => {

--- a/src/test/suite/ktableProvider.test.ts
+++ b/src/test/suite/ktableProvider.test.ts
@@ -25,14 +25,12 @@ suite('KTable Provider Test Suite', () => {
     });
 
     suite('Root Level', () => {
-        test('should return empty state when no clusters configured', async () => {
+        test('should return empty array when no clusters configured', async () => {
             getClustersStub.returns([]);
 
             const children = await provider.getChildren();
 
-            assert.strictEqual(children.length, 1);
-            assert.strictEqual(children[0].label, 'No clusters configured.');
-            assert.strictEqual(children[0].contextValue, 'empty');
+            assert.strictEqual(children.length, 0);
         });
 
         test('should return cluster items when clusters exist', async () => {

--- a/src/test/suite/providers.test.ts
+++ b/src/test/suite/providers.test.ts
@@ -44,8 +44,9 @@ suite('Provider Test Suite', () => {
             sandbox.stub(clientManager, 'getClusters').returns([]);
 
             const children = await provider.getChildren();
-            assert.ok(Array.isArray(children));
+            assert.strictEqual(children.length, 0, 'Should return empty array to trigger viewsWelcome');
         });
+
     });
 
     suite('ConsumerGroupProvider', () => {

--- a/src/views/DetailsWebview.ts
+++ b/src/views/DetailsWebview.ts
@@ -1098,13 +1098,7 @@ export class DetailsWebview extends BaseWebviewWithAI {
                                 🤖 Get AI Details
                             </button>
                         </div>
-                        ` : `
-                        <div class="info-modal-footer" style="justify-content: center;">
-                            <div style="color: var(--vscode-descriptionForeground); font-size: 12px; text-align: center; padding: 8px;">
-                                💡 Install <a href="https://marketplace.visualstudio.com/items?itemName=GitHub.copilot" target="_blank" style="color: var(--vscode-textLink-foreground);">GitHub Copilot</a> to enable AI-powered parameter details
-                            </div>
-                        </div>
-                        `}
+                        ` : ''}
                     </div>
                 </div>
 


### PR DESCRIPTION
- Replace hardcoded gpt-4/gpt-3.5-turbo family filters in AIAdvisor and parameterAIService with selectChatModels({}) so any registered VS Code LM provider (Copilot, Claude extensions, etc.) is detected correctly
- Cache resolved models in AIAdvisor to avoid double selectChatModels calls per operation; clear cache on sendRequest failure for automatic recovery after Copilot restarts
- Wire up showAIAdvisor and setAIRequestHandler for consumer group details view, which was missing AI support entirely
- Remove misleading "Install GitHub Copilot" prompt from parameter info modal footer; show nothing when no LM is available
- Replace empty-state placeholder tree items with viewsWelcome contributions for all 5 views (kafkaExplorer, kafkaConsumerGroups, kafkaBrokers, kafkaStreams, kafkaTables) so VS Code renders the native welcome panel with an Add Cluster button
- Remove redundant activationEvents (auto-generated by VS Code 1.74+)
- Add ts-node as explicit devDependency (dropped by npm audit fix)
- Update tests to assert empty array at root when no clusters configured