### PR TITLE
fix: prevent unreachable cluster from blocking extension startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the "Kafka Client" extension will be documented in this f
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.12.10](https://github.com/nipunap/vscode-kafka-client/compare/v0.12.9...v0.12.10) (2026-04-26)
+
+
+### 🐛 Bug Fixes
+
+* prevent unreachable cluster from blocking extension startup ([30ac912](https://github.com/nipunap/vscode-kafka-client/commit/30ac9126ae80207196fac49d78275bc5ed9b3dc7)), closes [#55](https://github.com/nipunap/vscode-kafka-client/issues/55)
+* resolve moderate npm dependency vulnerabilities ([0c76e94](https://github.com/nipunap/vscode-kafka-client/commit/0c76e94d13fe92ff74b736dcc93d64077428eeff))
+
 ## [0.12.9](https://github.com/nipunap/vscode-kafka-client/compare/v0.12.8...v0.12.9) (2026-04-20)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "vscode-kafka-client",
-  "version": "0.12.8",
+  "version": "0.12.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-kafka-client",
-      "version": "0.12.8",
+      "version": "0.12.9",
       "license": "GPL-3.0",
       "dependencies": {
         "@aws-sdk/client-kafka": "^3.990.0",
         "@aws-sdk/client-sts": "^3.990.0",
         "@aws-sdk/credential-providers": "^3.990.0",
         "@aws/lambda-invoke-store": "^0.1.0",
-        "@kafkajs/confluent-schema-registry": "^3.9.0",
+        "@kafkajs/confluent-schema-registry": "^4.0.8",
         "aws-msk-iam-sasl-signer-js": "github:aws/aws-msk-iam-sasl-signer-js",
         "ini": "^5.0.0",
         "kafkajs": "^2.2.4"
@@ -1957,15 +1957,30 @@
       }
     },
     "node_modules/@kafkajs/confluent-schema-registry": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@kafkajs/confluent-schema-registry/-/confluent-schema-registry-3.9.0.tgz",
-      "integrity": "sha512-QiwinzNVlHPvylFCSiKBcTDxNDp9/xDj7ZWTxlsel5h4hwLxMLjnuJUcW/LhzNPPi/V4Vfa4Yq0uv30CYGtRnA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@kafkajs/confluent-schema-registry/-/confluent-schema-registry-4.0.8.tgz",
+      "integrity": "sha512-puREyVQoLrrvn7It+V8U64XsGEfDW5kjTgP8OoBbkqJxo+C0f0/53RkUnXf0cQG05Z14cko8bLLzCSxmHrR7pQ==",
       "dependencies": {
-        "ajv": "^7.1.0",
+        "ajv": "^8.18.0",
         "avsc": ">= 5.4.13 < 6",
         "mappersmith": ">= 2.44.0 < 3",
         "protobufjs": "^7.4.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -3334,15 +3349,15 @@
       }
     },
     "node_modules/ajv": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.4.tgz",
-      "integrity": "sha512-nBeQgg/ZZA3u3SYxyaDvpvDtgZ/EZPF547ARgZBrG9Bhu1vKDwAIjtIf+sDtJUKa2zOcEbmRLBRSyMraS/Oy1A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -5678,6 +5693,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fast-xml-builder": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
@@ -5694,9 +5725,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.8",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
-      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
       "funding": [
         {
           "type": "github",
@@ -5705,9 +5736,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.0"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -9207,6 +9239,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -10788,6 +10821,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -658,7 +658,8 @@
   },
   "overrides": {
     "serialize-javascript": "7.0.5",
-    "diff": "8.0.3"
+    "diff": "8.0.3",
+    "fast-xml-parser": "5.7.2"
   },
   "devDependencies": {
     "@types/ini": "^4.1.1",
@@ -686,7 +687,7 @@
     "@aws-sdk/client-sts": "^3.990.0",
     "@aws-sdk/credential-providers": "^3.990.0",
     "@aws/lambda-invoke-store": "^0.1.0",
-    "@kafkajs/confluent-schema-registry": "^3.9.0",
+    "@kafkajs/confluent-schema-registry": "^4.0.8",
     "aws-msk-iam-sasl-signer-js": "github:aws/aws-msk-iam-sasl-signer-js",
     "ini": "^5.0.0",
     "kafkajs": "^2.2.4"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-kafka-client",
   "displayName": "Kafka Client",
   "description": "Full-featured Kafka client with AWS MSK support, IAM authentication, role assumption, and auto-discovery",
-  "version": "0.12.9",
+  "version": "0.12.10",
   "publisher": "NipunaPerera",
   "license": "GPL-3.0",
   "pricing": "Free",

--- a/src/kafka/kafkaClientManager.ts
+++ b/src/kafka/kafkaClientManager.ts
@@ -164,20 +164,9 @@ export class KafkaClientManager {
             kafkaConfig.sasl = await this.buildSASLConfig(connection);
         }
 
-        // Create Kafka instance
+        // Create Kafka instance (connection established lazily via getAdmin() on first use)
         const kafka = new Kafka(kafkaConfig);
         this.kafkaInstances.set(connection.name, kafka);
-
-        // Test connection
-        try {
-            const admin = kafka.admin();
-            await admin.connect();
-            this.admins.set(connection.name, admin);
-        } catch (error) {
-            // Connection failed, but still save the config
-            // We'll try to connect later when needed
-            console.warn(`Failed to connect to cluster ${connection.name} on startup:`, error);
-        }
 
         // Save configuration using ConfigurationService
         this.saveConfiguration();
@@ -262,7 +251,7 @@ export class KafkaClientManager {
             clientId: `vscode-kafka-${connection.name}`,
             brokers: brokerList,
             logLevel: logLevel.ERROR,
-            connectionTimeout: 30000,
+            connectionTimeout: vscode.workspace.getConfiguration('kafka').get('connectionTimeoutMs', 30000),
             requestTimeout: 60000,
             authenticationTimeout: 30000,
             retry: {
@@ -1314,66 +1303,68 @@ export class KafkaClientManager {
 
         const failedClusters: { name: string; reason: string }[] = [];
 
-        for (const cluster of clusters) {
-            // Validate cluster configuration
-            if (!this.validateClusterConfig(cluster)) {
-                console.error(`Invalid cluster configuration for "${cluster.name}"`);
-                failedClusters.push({
-                    name: cluster.name || 'Unknown',
-                    reason: 'Invalid configuration (missing required fields)'
-                });
-                continue;
-            }
-
-            try {
-                // Reconstruct the full cluster connection from saved config
-                const connection: ClusterConnection = {
-                    name: cluster.name,
-                    type: cluster.type || 'kafka',
-                    brokers: cluster.brokers || [],
-                    securityProtocol: cluster.securityProtocol || 'PLAINTEXT',
-
-                    // MSK-specific fields
-                    region: cluster.region,
-                    clusterArn: cluster.clusterArn,
-                    awsProfile: cluster.awsProfile,
-                    assumeRoleArn: cluster.assumeRoleArn,
-
-                    // SASL fields
-                    saslMechanism: cluster.saslMechanism,
-                    // Note: We don't save passwords, so SASL clusters will need re-authentication
-
-                    // SSL fields
-                    sslCaFile: cluster.sslCaFile,
-                    sslCertFile: cluster.sslCertFile,
-                    sslKeyFile: cluster.sslKeyFile,
-                    rejectUnauthorized: cluster.rejectUnauthorized
-                };
-
-                // Use the same method as adding a new cluster to ensure consistency
-                await this.addClusterFromConnection(connection);
-
-            } catch (error: any) {
-                // Log the error using the logger instead of console
-                this.logger.error(`Failed to load cluster ${cluster.name}`, error);
-
-                // Determine the reason for failure
-                const errorMsg = error?.message || error.toString();
-
-                let reason: string;
-                if (errorMsg.includes('expired') || errorMsg.includes('credentials')) {
-                    reason = 'AWS credentials expired or invalid';
-                } else if (errorMsg.includes('brokers')) {
-                    reason = 'Failed to fetch brokers';
-                } else if (errorMsg.includes('network') || errorMsg.includes('timeout')) {
-                    reason = 'Network connection failed';
-                } else {
-                    reason = errorMsg.substring(0, 100);
+        await Promise.allSettled(
+            clusters.map(async cluster => {
+                // Validate cluster configuration
+                if (!this.validateClusterConfig(cluster)) {
+                    console.error(`Invalid cluster configuration for "${cluster.name}"`);
+                    failedClusters.push({
+                        name: cluster.name || 'Unknown',
+                        reason: 'Invalid configuration (missing required fields)'
+                    });
+                    return;
                 }
 
-                failedClusters.push({ name: cluster.name, reason });
-            }
-        }
+                try {
+                    // Reconstruct the full cluster connection from saved config
+                    const connection: ClusterConnection = {
+                        name: cluster.name,
+                        type: cluster.type || 'kafka',
+                        brokers: cluster.brokers || [],
+                        securityProtocol: cluster.securityProtocol || 'PLAINTEXT',
+
+                        // MSK-specific fields
+                        region: cluster.region,
+                        clusterArn: cluster.clusterArn,
+                        awsProfile: cluster.awsProfile,
+                        assumeRoleArn: cluster.assumeRoleArn,
+
+                        // SASL fields
+                        saslMechanism: cluster.saslMechanism,
+                        // Note: We don't save passwords, so SASL clusters will need re-authentication
+
+                        // SSL fields
+                        sslCaFile: cluster.sslCaFile,
+                        sslCertFile: cluster.sslCertFile,
+                        sslKeyFile: cluster.sslKeyFile,
+                        rejectUnauthorized: cluster.rejectUnauthorized
+                    };
+
+                    // Use the same method as adding a new cluster to ensure consistency
+                    await this.addClusterFromConnection(connection);
+
+                } catch (error: any) {
+                    // Log the error using the logger instead of console
+                    this.logger.error(`Failed to load cluster ${cluster.name}`, error);
+
+                    // Determine the reason for failure
+                    const errorMsg = error?.message || error.toString();
+
+                    let reason: string;
+                    if (errorMsg.includes('expired') || errorMsg.includes('credentials')) {
+                        reason = 'AWS credentials expired or invalid';
+                    } else if (errorMsg.includes('brokers')) {
+                        reason = 'Failed to fetch brokers';
+                    } else if (errorMsg.includes('network') || errorMsg.includes('timeout')) {
+                        reason = 'Network connection failed';
+                    } else {
+                        reason = errorMsg.substring(0, 100);
+                    }
+
+                    failedClusters.push({ name: cluster.name, reason });
+                }
+            })
+        );
 
         // Show notification if any clusters failed to load
         if (failedClusters.length > 0) {

--- a/src/providers/kafkaExplorerProvider.ts
+++ b/src/providers/kafkaExplorerProvider.ts
@@ -9,8 +9,6 @@ export class KafkaExplorerProvider extends BaseProvider<KafkaTreeItem> {
 
     constructor(clientManager: KafkaClientManager) {
         super(clientManager, 'KafkaExplorerProvider');
-        // Load saved clusters on startup
-        this.clientManager.loadConfiguration();
     }
 
     /**


### PR DESCRIPTION
Fixes #55

## Problem

When one or more clusters are unreachable (e.g. VPN disconnected), the entire extension hangs for up to 15 minutes — including locally-running clusters that should be unaffected. Two compounding bugs caused this:

1. **Sequential startup loading** — clusters were loaded one-by-one in a `for` loop; a slow/unreachable cluster blocked all subsequent ones
2. **Eager connection test at startup** — `addClusterFromConnection()` called `admin.connect()` immediately with 30s timeout × 3 retries = up to ~127s per cluster; on Windows, TCP hangs to VPN endpoints can exceed this indefinitely

## Changes

**`src/kafka/kafkaClientManager.ts`**
- Remove eager `admin.connect()` from `addClusterFromConnection()` — connections are now established lazily via `getAdmin()` when the user first expands a cluster in the tree. Unreachable brokers no longer block startup.
- Parallelize `loadConfiguration()` with `Promise.allSettled()` — all clusters load simultaneously. A VPN-disconnected cluster no longer delays locally-reachable ones.
- Wire up the existing `kafka.connectionTimeoutMs` VS Code setting in `buildKafkaConfig()` instead of hardcoding 30000ms, letting users tune the timeout for their environment.

**`src/providers/kafkaExplorerProvider.ts`**
- Remove duplicate `loadConfiguration()` call from the constructor — `extension.ts` already calls it on activation, causing double connection attempts and duplicate error log cycles on startup.

## Behaviour After Fix

- Extension loads all cluster names in the tree within ~1 second regardless of unreachable brokers
- Expanding a reachable cluster → topics/brokers load immediately
- Expanding an unreachable cluster → shows error after `connectionTimeoutMs` (default 30s), isolated to that cluster only
- No more 15-minute hangs on Windows with VPN-dependent clusters

🤖 Generated with [Claude Code](https://claude.com/claude-code)